### PR TITLE
Made AwsEbDeploy exit with error if no WAR file found.

### DIFF
--- a/scripts/AwsEbDeploy.groovy
+++ b/scripts/AwsEbDeploy.groovy
@@ -58,7 +58,8 @@ target(main: "Deploy Grails WAR file to AWS Elastic Beanstalk") {
 
     File appWarFile = getAppWarFile(warFileName)
     if(!appWarFile.exists()) {
-        //TODO log error
+        println "Could not find WAR file to upload.  Expected: $appWarFile.absolutePath"
+        exit 1
     }
 
     println "Finding S3 bucket to upload WAR"


### PR DESCRIPTION
Hi, just got a bit confused by this plugin when I hadn't run grails-war previously.

Added error and script exit with non-zero status code when WAR file was not found.
